### PR TITLE
Feature/code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
         run: go mod download
 
       - name: Run tests
-        run: go test -v -race -coverprofile=coverage.out ./...
+        run: go test -v -race -coverprofile=coverage.txt ./...
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         if: matrix.go-version == '1.22'
         with:
-          file: ./coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: '1.22'
 
       - name: Run tests
-        run: go test -v -coverprofile=coverage.txt ./...
+        run: go test -v -race -coverprofile=coverage.txt ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,12 @@ jobs:
           go-version: '1.22'
 
       - name: Run tests
-        run: go test -v ./...
+        run: go test -v -coverprofile=coverage.txt ./...
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This pull request updates the CI and release workflows to improve test coverage reporting and ensure compatibility with the latest Codecov GitHub Action. The main changes involve updating the test commands to generate coverage reports and switching to a newer version of the Codecov action with proper authentication.

**CI and test coverage improvements:**

* Updated the test command in `.github/workflows/ci.yml` and `.github/workflows/release.yml` to generate coverage reports as `coverage.txt` and include race detection for more robust testing. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL33-R39) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L27-R32)
* Upgraded the Codecov GitHub Action from version 4 to version 5 for both workflows to ensure continued support and security. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL33-R39) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L27-R32)
* Added the use of the `CODECOV_TOKEN` secret for authentication when uploading coverage reports, improving security and reliability of coverage uploads. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL33-R39) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L27-R32)