### PR TITLE
Add client portal switch functionality and corresponding tests

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -204,3 +204,42 @@ func (s *ClientsService) GetStatement(ctx context.Context, req *StatementRequest
 	// This would need special handling for PDF response
 	return nil, fmt.Errorf("not implemented - use client.Request with custom handling")
 }
+
+// ClientPortalSwitchRequest represents a request to switch to client portal.
+type ClientPortalSwitchRequest struct {
+	// ContactID is the ID of the contact to generate the portal link for.
+	// If empty, the primary contact will be used.
+	ContactID string `json:"contact_id,omitempty"`
+}
+
+// ClientPortalSwitchResponse represents the response from switching to client portal.
+type ClientPortalSwitchResponse struct {
+	// URL is the client portal URL that can be used to access the portal.
+	URL string `json:"url"`
+}
+
+// SwitchToClientPortal generates a magic link URL for client portal access.
+// The link allows the client to access their portal without password authentication.
+// The contactID parameter is optional; if empty, the primary contact is used.
+func (s *ClientsService) SwitchToClientPortal(ctx context.Context, clientID string, contactID string) (*ClientPortalSwitchResponse, error) {
+	path := fmt.Sprintf("/api/v1/client_portal/%s/switch_company", clientID)
+
+	// Add contact_id as query parameter if specified
+	var query url.Values
+	if contactID != "" {
+		query = url.Values{}
+		query.Set("contact_id", contactID)
+	}
+
+	var resp ClientPortalSwitchResponse
+	if err := s.client.doRequest(ctx, "POST", path, query, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetClientPortalURL generates a client portal access URL for a contact.
+// This is a convenience wrapper around SwitchToClientPortal.
+func (s *ClientsService) GetClientPortalURL(ctx context.Context, clientID string) (*ClientPortalSwitchResponse, error) {
+	return s.SwitchToClientPortal(ctx, clientID, "")
+}

--- a/clients_test.go
+++ b/clients_test.go
@@ -325,3 +325,83 @@ func TestClientListOptionsNilToQuery(t *testing.T) {
 		t.Error("expected nil query for nil options")
 	}
 }
+
+func TestClientsServiceSwitchToClientPortal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST method, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/client_portal/client123/switch_company" {
+			t.Errorf("expected path /api/v1/client_portal/client123/switch_company, got %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"url": "https://example.invoicing.co/client/portal/abc123xyz",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token", WithBaseURL(server.URL))
+
+	resp, err := client.Clients.SwitchToClientPortal(context.Background(), "client123", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.URL != "https://example.invoicing.co/client/portal/abc123xyz" {
+		t.Errorf("expected URL to be magic link, got '%s'", resp.URL)
+	}
+}
+
+func TestClientsServiceSwitchToClientPortalWithContact(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST method, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/client_portal/client123/switch_company" {
+			t.Errorf("expected path /api/v1/client_portal/client123/switch_company, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("contact_id") != "contact456" {
+			t.Errorf("expected contact_id=contact456, got %s", r.URL.Query().Get("contact_id"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"url": "https://example.invoicing.co/client/portal/def456abc",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token", WithBaseURL(server.URL))
+
+	resp, err := client.Clients.SwitchToClientPortal(context.Background(), "client123", "contact456")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.URL != "https://example.invoicing.co/client/portal/def456abc" {
+		t.Errorf("expected URL to be magic link, got '%s'", resp.URL)
+	}
+}
+
+func TestClientsServiceGetClientPortalURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"url": "https://example.invoicing.co/client/portal/primary123",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token", WithBaseURL(server.URL))
+
+	resp, err := client.Clients.GetClientPortalURL(context.Background(), "client123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.URL == "" {
+		t.Error("expected non-empty URL")
+	}
+}


### PR DESCRIPTION
This pull request adds support for generating magic link URLs for client portal access in the `ClientsService`, allowing clients (and optionally specific contacts) to access their portal without password authentication. It introduces new request/response types, two new service methods, and comprehensive tests to ensure correct behavior.

**Client Portal Magic Link Feature:**

* Added `ClientPortalSwitchRequest` and `ClientPortalSwitchResponse` types to represent requests and responses for generating client portal magic links.
* Implemented `SwitchToClientPortal` method in `ClientsService` to generate a magic link URL for client portal access, supporting an optional `contactID` parameter.
* Added `GetClientPortalURL` as a convenience wrapper to generate a portal URL for the primary contact.

**Testing:**

* Added tests for `SwitchToClientPortal` (with and without `contactID`) and `GetClientPortalURL` to verify correct HTTP requests and response handling.