### PR TITLE
Implement client portal switch functionality with enhanced error handling and tests

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -221,21 +221,57 @@ type ClientPortalSwitchResponse struct {
 // SwitchToClientPortal generates a magic link URL for client portal access.
 // The link allows the client to access their portal without password authentication.
 // The contactID parameter is optional; if empty, the primary contact is used.
+//
+// This method fetches the client to get the contact_key, then constructs the portal URL
+// using the pattern: {baseURL}/client/key_login/{contact_key}
 func (s *ClientsService) SwitchToClientPortal(ctx context.Context, clientID string, contactID string) (*ClientPortalSwitchResponse, error) {
-	path := fmt.Sprintf("/api/v1/client_portal/%s/switch_company", clientID)
+	// Fetch the client with contacts to get contact keys
+	client, err := s.Get(ctx, clientID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client: %w", err)
+	}
 
-	// Add contact_id as query parameter if specified
-	var query url.Values
+	if len(client.Contacts) == 0 {
+		return nil, fmt.Errorf("client has no contacts")
+	}
+
+	// Find the appropriate contact
+	var contact *ClientContact
 	if contactID != "" {
-		query = url.Values{}
-		query.Set("contact_id", contactID)
+		// Find specific contact by ID
+		for i := range client.Contacts {
+			if client.Contacts[i].ID == contactID {
+				contact = &client.Contacts[i]
+				break
+			}
+		}
+		if contact == nil {
+			return nil, fmt.Errorf("contact with ID %s not found", contactID)
+		}
+	} else {
+		// Use primary contact, or first contact if none is marked primary
+		for i := range client.Contacts {
+			if client.Contacts[i].IsPrimary {
+				contact = &client.Contacts[i]
+				break
+			}
+		}
+		if contact == nil {
+			contact = &client.Contacts[0]
+		}
 	}
 
-	var resp ClientPortalSwitchResponse
-	if err := s.client.doRequest(ctx, "POST", path, query, nil, &resp); err != nil {
-		return nil, err
+	if contact.ContactKey == "" {
+		return nil, fmt.Errorf("contact has no contact_key - portal access may be disabled")
 	}
-	return &resp, nil
+
+	// Construct the portal URL using the contact key
+	// Format: {baseURL}/client/key_login/{contact_key}
+	portalURL := fmt.Sprintf("%s/client/key_login/%s", s.client.baseURL, contact.ContactKey)
+
+	return &ClientPortalSwitchResponse{
+		URL: portalURL,
+	}, nil
 }
 
 // GetClientPortalURL generates a client portal access URL for a contact.

--- a/clients.go
+++ b/clients.go
@@ -223,7 +223,7 @@ type ClientPortalSwitchResponse struct {
 // The contactID parameter is optional; if empty, the primary contact is used.
 //
 // This method fetches the client to get the contact_key, then constructs the portal URL
-// using the pattern: {baseURL}/client/key_login/{contact_key}
+// using the pattern: {baseURL}/client/key_login/{contact_key}.
 func (s *ClientsService) SwitchToClientPortal(ctx context.Context, clientID string, contactID string) (*ClientPortalSwitchResponse, error) {
 	// Fetch the client with contacts to get contact keys
 	client, err := s.Get(ctx, clientID)

--- a/clients_test.go
+++ b/clients_test.go
@@ -328,16 +328,29 @@ func TestClientListOptionsNilToQuery(t *testing.T) {
 
 func TestClientsServiceSwitchToClientPortal(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" {
-			t.Errorf("expected POST method, got %s", r.Method)
+		if r.Method != "GET" {
+			t.Errorf("expected GET method, got %s", r.Method)
 		}
-		if r.URL.Path != "/api/v1/client_portal/client123/switch_company" {
-			t.Errorf("expected path /api/v1/client_portal/client123/switch_company, got %s", r.URL.Path)
+		if r.URL.Path != "/api/v1/clients/client123" {
+			t.Errorf("expected path /api/v1/clients/client123, got %s", r.URL.Path)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"url": "https://example.invoicing.co/client/portal/abc123xyz",
+			"data": map[string]interface{}{
+				"id":   "client123",
+				"name": "Test Client",
+				"contacts": []map[string]interface{}{
+					{
+						"id":          "contact1",
+						"first_name":  "John",
+						"last_name":   "Doe",
+						"email":       "john@example.com",
+						"is_primary":  true,
+						"contact_key": "abc123xyz",
+					},
+				},
+			},
 		})
 	}))
 	defer server.Close()
@@ -349,26 +362,45 @@ func TestClientsServiceSwitchToClientPortal(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if resp.URL != "https://example.invoicing.co/client/portal/abc123xyz" {
-		t.Errorf("expected URL to be magic link, got '%s'", resp.URL)
+	expectedURL := server.URL + "/client/key_login/abc123xyz"
+	if resp.URL != expectedURL {
+		t.Errorf("expected URL to be %s, got '%s'", expectedURL, resp.URL)
 	}
 }
 
 func TestClientsServiceSwitchToClientPortalWithContact(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "POST" {
-			t.Errorf("expected POST method, got %s", r.Method)
+		if r.Method != "GET" {
+			t.Errorf("expected GET method, got %s", r.Method)
 		}
-		if r.URL.Path != "/api/v1/client_portal/client123/switch_company" {
-			t.Errorf("expected path /api/v1/client_portal/client123/switch_company, got %s", r.URL.Path)
-		}
-		if r.URL.Query().Get("contact_id") != "contact456" {
-			t.Errorf("expected contact_id=contact456, got %s", r.URL.Query().Get("contact_id"))
+		if r.URL.Path != "/api/v1/clients/client123" {
+			t.Errorf("expected path /api/v1/clients/client123, got %s", r.URL.Path)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"url": "https://example.invoicing.co/client/portal/def456abc",
+			"data": map[string]interface{}{
+				"id":   "client123",
+				"name": "Test Client",
+				"contacts": []map[string]interface{}{
+					{
+						"id":          "contact1",
+						"first_name":  "John",
+						"last_name":   "Doe",
+						"email":       "john@example.com",
+						"is_primary":  true,
+						"contact_key": "primary_key_123",
+					},
+					{
+						"id":          "contact456",
+						"first_name":  "Jane",
+						"last_name":   "Doe",
+						"email":       "jane@example.com",
+						"is_primary":  false,
+						"contact_key": "def456abc",
+					},
+				},
+			},
 		})
 	}))
 	defer server.Close()
@@ -380,8 +412,99 @@ func TestClientsServiceSwitchToClientPortalWithContact(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if resp.URL != "https://example.invoicing.co/client/portal/def456abc" {
-		t.Errorf("expected URL to be magic link, got '%s'", resp.URL)
+	expectedURL := server.URL + "/client/key_login/def456abc"
+	if resp.URL != expectedURL {
+		t.Errorf("expected URL to be %s, got '%s'", expectedURL, resp.URL)
+	}
+}
+
+func TestClientsServiceSwitchToClientPortal_NoContacts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":       "client123",
+				"name":     "Test Client",
+				"contacts": []map[string]interface{}{},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token", WithBaseURL(server.URL))
+
+	_, err := client.Clients.SwitchToClientPortal(context.Background(), "client123", "")
+	if err == nil {
+		t.Error("expected error for client with no contacts")
+	}
+	if err.Error() != "client has no contacts" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestClientsServiceSwitchToClientPortal_ContactNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":   "client123",
+				"name": "Test Client",
+				"contacts": []map[string]interface{}{
+					{
+						"id":          "contact1",
+						"first_name":  "John",
+						"last_name":   "Doe",
+						"email":       "john@example.com",
+						"is_primary":  true,
+						"contact_key": "abc123xyz",
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token", WithBaseURL(server.URL))
+
+	_, err := client.Clients.SwitchToClientPortal(context.Background(), "client123", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent contact ID")
+	}
+	if err.Error() != "contact with ID nonexistent not found" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestClientsServiceSwitchToClientPortal_NoContactKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":   "client123",
+				"name": "Test Client",
+				"contacts": []map[string]interface{}{
+					{
+						"id":         "contact1",
+						"first_name": "John",
+						"last_name":  "Doe",
+						"email":      "john@example.com",
+						"is_primary": true,
+						// contact_key is missing
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient("test-token", WithBaseURL(server.URL))
+
+	_, err := client.Clients.SwitchToClientPortal(context.Background(), "client123", "")
+	if err == nil {
+		t.Error("expected error for contact with no contact_key")
+	}
+	if err.Error() != "contact has no contact_key - portal access may be disabled" {
+		t.Errorf("unexpected error message: %v", err)
 	}
 }
 
@@ -389,7 +512,20 @@ func TestClientsServiceGetClientPortalURL(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"url": "https://example.invoicing.co/client/portal/primary123",
+			"data": map[string]interface{}{
+				"id":   "client123",
+				"name": "Test Client",
+				"contacts": []map[string]interface{}{
+					{
+						"id":          "contact1",
+						"first_name":  "John",
+						"last_name":   "Doe",
+						"email":       "john@example.com",
+						"is_primary":  true,
+						"contact_key": "primary123",
+					},
+				},
+			},
 		})
 	}))
 	defer server.Close()
@@ -401,7 +537,8 @@ func TestClientsServiceGetClientPortalURL(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if resp.URL == "" {
-		t.Error("expected non-empty URL")
+	expectedURL := server.URL + "/client/key_login/primary123"
+	if resp.URL != expectedURL {
+		t.Errorf("expected URL to be %s, got '%s'", expectedURL, resp.URL)
 	}
 }

--- a/models.go
+++ b/models.go
@@ -181,6 +181,7 @@ type ClientContact struct {
 	Email        string `json:"email,omitempty"`
 	Phone        string `json:"phone,omitempty"`
 	IsPrimary    bool   `json:"is_primary,omitempty"`
+	ContactKey   string `json:"contact_key,omitempty"`
 	CustomValue1 string `json:"custom_value1,omitempty"`
 	CustomValue2 string `json:"custom_value2,omitempty"`
 	CustomValue3 string `json:"custom_value3,omitempty"`


### PR DESCRIPTION
This pull request refactors the implementation of the `SwitchToClientPortal` method in the clients service to generate client portal magic links using the contact's `contact_key` instead of calling a dedicated API endpoint. It also updates and expands the test suite to cover new edge cases and ensures correct behavior when handling contacts.

Key changes include:

### Refactor of client portal magic link logic

* The `SwitchToClientPortal` method in `ClientsService` now fetches the client and constructs the portal URL using the contact's `contact_key`, rather than making a POST request to a specific endpoint. This includes improved error handling for cases where contacts are missing or the contact key is absent.

### Model updates

* The `ClientContact` struct in `models.go` now includes a `ContactKey` field, which is used to build the magic link for portal access.

### Test suite improvements

* Updated existing tests for `SwitchToClientPortal` to reflect the new logic (using GET instead of POST, different endpoint, and checking the constructed URL).
* Added new tests to cover edge cases:
  - No contacts present for the client.
  - Specified contact ID not found.
  - Contact exists but has no `contact_key`.
  - Updated expectations for generated URLs to match the new logic. [[1]](diffhunk://#diff-edaa48212807abc384fd0bd5ae6f1caeb8a2197312dbcc8ce45d729c38394df3L331-R353) [[2]](diffhunk://#diff-edaa48212807abc384fd0bd5ae6f1caeb8a2197312dbcc8ce45d729c38394df3L352-R403) [[3]](diffhunk://#diff-edaa48212807abc384fd0bd5ae6f1caeb8a2197312dbcc8ce45d729c38394df3L383-R528) [[4]](diffhunk://#diff-edaa48212807abc384fd0bd5ae6f1caeb8a2197312dbcc8ce45d729c38394df3L404-R542)